### PR TITLE
delay font initialization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,11 +5,22 @@ const charPreset = require('./char-preset');
 const chToPath = require('./ch-to-path');
 const random = require('./random');
 
-const fontPath = path.join(__dirname, '../fonts/Comismsh.ttf');
-let font = opentype.loadSync(fontPath);
+// static font initialization fails webpack builds
+// delaying font initialization will allow applications to configure font in advance
+// const fontPath = path.join(__dirname, '../fonts/Comismsh.ttf');
+// let font = opentype.loadSync(fontPath);
+let font = null;
 
 function loadFont(filepath) {
-	font = opentype.loadSync(filepath);
+	// load / reload font
+	if (filepath != null) {
+		font = opentype.loadSync(filepath);
+	}
+
+	// default unconfigured behaviour
+	if (font == null && filepath == null) {
+		font = opentype.loadSync(path.join(__dirname, '../fonts/Comismsh.ttf'))
+	}
 }
 
 function getLineNoise (width, height, noise, background) {
@@ -28,6 +39,9 @@ function getLineNoise (width, height, noise, background) {
 };
 
 const getText = function (text, width, height, options) {
+	// make sure that some font is loaded
+	loadFont(null);
+	
 	const len = text.length;
 	const spacing = (width - 2) / (len + 1);
 	const min = options.inverse ? 10 : 0;


### PR DESCRIPTION
static font initialization fails webpack builds, also builds may note have access to __dirname
delaying font initialization will allow applications to configure font in advance

